### PR TITLE
Dockerize the shiny app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# No log files
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rocker/shiny
+MAINTAINER Colin Fleming <c3flemin@gmail.com>
+
+# configure environment variable
+# note: move this to three ARG commands when CircleCI updates their docker
+ENV DCAF_DIR=/usr/src/app
+
+# get our gem house in order
+RUN mkdir -p ${DCAF_DIR} && cd ${DCAF_DIR}
+WORKDIR ${DCAF_DIR}
+COPY packages.R ${DCAF_DIR}/packages.R
+
+# install packages
+RUN Rscript packages.R
+
+# Move the rest of the app over
+COPY . ${DCAF_DIR}
+
+EXPOSE 3838

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DCAF_DIR=/usr/src/app \
     SHINY_DIR=/srv/shiny-server
 
 # get our gem house in order
-RUN mkdir -p ${DCAF_DIR} && cd ${DCAF_DIR}
+RUN mkdir -p ${DCAF_DIR}
 WORKDIR ${DCAF_DIR}
 COPY packages.R ${DCAF_DIR}/packages.R
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM rocker/shiny
+FROM rocker/shiny-verse
 MAINTAINER Colin Fleming <c3flemin@gmail.com>
 
 # configure environment variable
 # note: move this to three ARG commands when CircleCI updates their docker
-ENV DCAF_DIR=/usr/src/app
+ENV DCAF_DIR=/usr/src/app \
+    SHINY_DIR=/srv/shiny-server
 
 # get our gem house in order
 RUN mkdir -p ${DCAF_DIR} && cd ${DCAF_DIR}
@@ -15,5 +16,6 @@ RUN Rscript packages.R
 
 # Move the rest of the app over
 COPY . ${DCAF_DIR}
+COPY App/ ${SHINY_DIR}
 
 EXPOSE 3838

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 DARIA analytics, but shiny
 
 This R shiny app takes a .csv from DARIA and provides analytics based off that.
+
+## Firing it up
+
+* `docker-compose up`
+* http://localhost:3838

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3838:3838"
+    volumes:
+      - log:/var/log/shiny-server
+
+volumes:
+  log:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+services:
+  shiny:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3838:3838"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "3838:3838"
     volumes:
       - log:/var/log/shiny-server
+      - ./App:/srv/shiny-server
 
 volumes:
   log:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,5 @@ services:
     ports:
       - "3838:3838"
     volumes:
-      - log:/var/log/shiny-server
+      - ./log:/var/log/shiny-server
       - ./App:/srv/shiny-server
-
-volumes:
-  log:

--- a/packages.R
+++ b/packages.R
@@ -1,0 +1,7 @@
+# Shiny is implied thanks to our Docker image
+pkgs = c(
+  'highcharter',
+  'dplyr'
+)
+
+install.packages(pkgs, quiet=TRUE)

--- a/packages.R
+++ b/packages.R
@@ -1,7 +1,7 @@
 # Shiny is implied thanks to our Docker image
+# So are the tidyverse suite of packages - https://www.tidyverse.org/packages/
 pkgs = c(
-  'highcharter',
-  'dplyr'
+  'highcharter'
 )
 
 install.packages(pkgs, quiet=TRUE)


### PR DESCRIPTION
This sets up a docker container to run the shiny server, albeit ugly.

I didn't do a volume - the image needs shiny stuff to be set up in /srv/shiny-server and I'm not savvy enough to figure that out. But, like, starting the server works!

@DarthHater could you spot check my work here, and if you want suggest any linux pkgs to add in setup given that we'll probably be running something similar to this in prod, I'm def all ears. These images are debian based, I believe. You should be able to recreate with instructions in the readme.

Fixes #9 
Bumps #3 